### PR TITLE
📝 Docs: Document Torrent and Scraper Services

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,12 +1,15 @@
-import { handleErrorWithSentry } from '@sentry/sveltekit';
+import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
-	dsn: 'https://9de97d2619224108bd22d5b32502ca76@o4508616651505664.ingest.us.sentry.io/4510840434262016',
+  dsn: 'https://9de97d2619224108bd22d5b32502ca76@o4508616651505664.ingest.us.sentry.io/4510840434262016',
 
-	// Enable sending user PII (Personally Identifiable Information)
-	// https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
-	sendDefaultPii: true
+
+
+
+  // Enable sending user PII (Personally Identifiable Information)
+  // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
+  sendDefaultPii: true,
 });
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,15 +1,12 @@
-import { handleErrorWithSentry, replayIntegration } from "@sentry/sveltekit";
+import { handleErrorWithSentry } from '@sentry/sveltekit';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
-  dsn: 'https://9de97d2619224108bd22d5b32502ca76@o4508616651505664.ingest.us.sentry.io/4510840434262016',
+	dsn: 'https://9de97d2619224108bd22d5b32502ca76@o4508616651505664.ingest.us.sentry.io/4510840434262016',
 
-
-
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
+	// Enable sending user PII (Personally Identifiable Information)
+	// https://docs.sentry.io/platforms/javascript/guides/sveltekit/configuration/options/#sendDefaultPii
+	sendDefaultPii: true
 });
 
 // If you have a custom error handler, pass it to `handleErrorWithSentry`

--- a/src/lib/server/services/scraper/index.ts
+++ b/src/lib/server/services/scraper/index.ts
@@ -6,7 +6,24 @@ import { isValidHttpUrl } from '$lib/url';
 export const REGEX_MATCH_MAGNET = /(magnet:[^"' ]*)/g;
 export const REGEX_MATCH_INFOHASH = /[0-9A-F]{40}/i;
 
+/**
+ * Orchestration service for resolving search results into actual torrent streams.
+ * Acts as the bridge between search engine results, direct torrent downloads, and HTML scraping.
+ */
 export default class ScraperService extends BaseService {
+	/**
+	 * Inspects a given URL to fetch and decode torrent data based on the HTTP `Content-Type`.
+	 *
+	 * - If it identifies a `.torrent` file (via MIME type or URL extension), it downloads
+	 *   and decodes the bencoded buffer.
+	 * - Otherwise, it fetches the HTML and scrapes the page using regex for magnet URIs.
+	 *
+	 * Note: Bypasses fetching entirely if the `url` is an invalid HTTP string.
+	 *
+	 * @param url - The external site URL or direct `.torrent` download link
+	 * @param referer - Optional referer header for bypassing hotlinking protection on certain trackers
+	 * @returns An array of parsed `TorrentStream`s found at the target URL
+	 */
 	async fetchTorrentsInSite(url: string, referer?: string): Promise<TorrentStream[]> {
 		if (!isValidHttpUrl(url)) {
 			return [];
@@ -41,6 +58,19 @@ export default class ScraperService extends BaseService {
 		}
 	}
 
+	/**
+	 * Main workflow to discover torrent streams for a given IMDb title.
+	 *
+	 * 1. Fetches the readable title from IMDb.
+	 * 2. Queries multiple search engines concurrently (`SearchService`).
+	 * 3. Ranks and limits the unified links (`RankService`).
+	 * 4. Iterates over the top links to fetch their actual torrents (`fetchTorrentsInSite`).
+	 *    - Employs a staggered jitter delay during concurrent fetching to avoid HTTP burst limits.
+	 * 5. Deduplicates all found streams by `infoHash` and returns the final unique list.
+	 *
+	 * @param imdbId - The canonical IMDb identifier (e.g. "tt0111161")
+	 * @returns An array of unique, parsed torrent streams corresponding to the given title
+	 */
 	async getTorrentStreams(imdbId: string): Promise<TorrentStream[]> {
 		const title = await this.services.imdb.getTitleById(imdbId);
 		const searchResults = await this.services.search.search(title);

--- a/src/lib/server/services/torrent/index.ts
+++ b/src/lib/server/services/torrent/index.ts
@@ -7,7 +7,20 @@ export interface TorrentStream {
 	title: string;
 }
 
+/**
+ * Service for parsing and decoding torrent data formats.
+ * Normalizes both raw `.torrent` files and magnet URIs into a standard `TorrentStream` object
+ * containing an uppercase `infoHash` and a sanitized `title`.
+ */
 export default class TorrentService extends BaseService {
+	/**
+	 * Extracts the infohash and display name from a raw bencoded `.torrent` file buffer.
+	 * Computes the SHA-1 digest from the exact byte range of the `info` dictionary,
+	 * ensuring the hash matches what torrent clients expect. Titles are HTML-entity encoded via `he` to prevent XSS.
+	 *
+	 * @param torrent - The raw array buffer of a `.torrent` file
+	 * @returns The parsed stream containing `infoHash` and `title`, or null if decoding fails
+	 */
 	async decodeTorrent(torrent: ArrayBuffer): Promise<TorrentStream | null> {
 		try {
 			const unbencode = decodeBencode(torrent, null, null, 'utf8');
@@ -31,6 +44,14 @@ export default class TorrentService extends BaseService {
 		}
 	}
 
+	/**
+	 * Parses a magnet URI string to extract the `infoHash` (`xt` parameter) and title (`dn` parameter).
+	 * Handles standard URI parsing via `new URL()` as well as a regex fallback for malformed or non-standard `magnet:?` strings.
+	 * Currently accepts both 40-character Hex and 32-character Base32 infohashes, normalizing them to uppercase.
+	 *
+	 * @param link - The raw magnet link string
+	 * @returns The parsed stream or null if the infohash is missing/invalid length
+	 */
 	parseMagnet(link: string): TorrentStream | null {
 		try {
 			const parsedURL = new URL(link);


### PR DESCRIPTION
**Assumptions:**
- `TorrentService` and `ScraperService` are the core domain components where documentations about info-hash generation, HTTP MIME detection, and IMDb mapping add the most value.
- Adding comprehensive JSDoc comments to these exported classes provides the best clarity for developers interacting with this system.
- The implementations function precisely as described in the added comments without altering any of the runtime logic.

**Alternatives Not Chosen:**
- **Refactoring:** Chose not to extract the regex constants or alter any actual parsing logic since the prompt enforces zero changes to executable logic.
- **Adding inline comments:** Preferential block-level JSDocs on class signatures and methods instead of polluting the body with inline `//` comments, complying with the "Avoid line comments" rule.
- **Broad Coverage:** Intentionally avoided documenting `SearchService` and other `services` folder classes in the same PR to maintain a tight scope ("ONE cohesive area per PR").

**How To Pivot:**
- If the team prefers the documentation to live closer to the interface definition rather than the class implementations, these JSDocs can easily be extracted into the `BaseService` or an abstract `TorrentStream` definition layer. 

**Next Knobs:**
- `src/lib/server/services/torrent/index.ts`: Expand the `parseMagnet` docs if more fallback regex cases are supported in the future.
- `src/lib/server/services/scraper/index.ts`: Document the specifics of the `RankService` logic within `getTorrentStreams` if the ranking algorithm gains new parameters.
- `src/lib/server/services/search/index.ts`: Provide a follow-up PR to document the concurrent search aggregation model, continuing from where `ScraperService` leaves off.

---
*PR created automatically by Jules for task [14583546622158114774](https://jules.google.com/task/14583546622158114774) started by @lucasew*