### PR TITLE
fix(search): rank and cap web search scrapes on the search page

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -10,10 +10,23 @@ if (query) {
 	const { services } = Astro.locals;
 	const searchResults = await services.search.search(query);
 
+	const refererMap = new Map(searchResults.map((r) => [r.link, r.source]));
+	const rankedLinks = services.rank.rank(searchResults.map((r) => r.link));
+	// Match scraper: only scrape the best candidates to avoid rate limits and junk domains
+	const topLinks = rankedLinks.slice(0, 10);
+
+	const sourceReferers: Record<string, string> = {
+		Google: 'https://www.google.com/',
+		DuckDuckGo: 'https://duckduckgo.com/',
+		Yandex: 'https://yandex.com/'
+	};
+
 	const fetched = await Promise.all(
-		searchResults.map(async (r) => {
-			const streams = await services.scraper.fetchTorrentsInSite(r.link).catch((e) => {
-				services.error.report(e, { url: r.link, message: 'fetchTorrentsInSite failed' });
+		topLinks.map(async (url) => {
+			const source = refererMap.get(url);
+			const referer = source ? sourceReferers[source] : undefined;
+			const streams = await services.scraper.fetchTorrentsInSite(url, referer).catch((e) => {
+				services.error.report(e, { url, message: 'fetchTorrentsInSite failed' });
 				return [];
 			});
 			return streams.map((s) => {
@@ -21,7 +34,7 @@ if (query) {
 				if (s.title) {
 					magnet += `&dn=${encodeURIComponent(s.title)}`;
 				}
-				return { magnet, source: r.source };
+				return { magnet, source: source ?? '' };
 			});
 		})
 	);


### PR DESCRIPTION
## Summary

The search page scraped every SERP hit in parallel with no ranking, no ignored-domain filter, and no referer headers. The Stremio path already does this right in `scraper.getTorrentStreams` (rank → top 10 → source referers).

`src/pages/search.astro` now mirrors that:

- Rank SERP links via `services.rank.rank` (drops ignored domains, prefers torrent-like URLs)
- Scrape only the top 10 candidates
- Pass Google / DuckDuckGo / Yandex referers into `fetchTorrentsInSite`
- Keep magnet building and magnet-string dedupe as before

No scraper rewrite; only the search page.

## Test plan

- [ ] `npx prettier --check --plugin=prettier-plugin-astro --plugin=prettier-plugin-svelte src/pages/search.astro`
- [ ] Open `/search?query=<something with torrents>` and confirm results still show
- [ ] Confirm fewer parallel scrapes / junk domains vs unbounded SERP fan-out
- [ ] Spot-check magnet links still build and dedupe correctly