### PR TITLE
fix(security): harden isValidHttpUrl against link-local and CGNAT ranges

### DIFF
--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -25,4 +25,27 @@ describe('isValidHttpUrl', () => {
 		expect(isValidHttpUrl('http://127.0.0.1')).toBe(false);
 		expect(isValidHttpUrl('http://localhost')).toBe(false);
 	});
+
+	it('should return false for IPv4 link-local and cloud metadata addresses', () => {
+		expect(isValidHttpUrl('http://169.254.169.254')).toBe(false);
+		expect(isValidHttpUrl('http://169.254.0.1')).toBe(false);
+		expect(isValidHttpUrl('https://169.254.1.1/latest/meta-data/')).toBe(false);
+	});
+
+	it('should return false for IPv4 CGNAT range 100.64.0.0/10', () => {
+		expect(isValidHttpUrl('http://100.64.0.1')).toBe(false);
+		expect(isValidHttpUrl('http://100.100.0.1')).toBe(false);
+		expect(isValidHttpUrl('http://100.127.255.254')).toBe(false);
+	});
+
+	it('should return true for public 100.x addresses outside CGNAT', () => {
+		expect(isValidHttpUrl('http://100.63.255.255')).toBe(true);
+		expect(isValidHttpUrl('http://100.128.0.1')).toBe(true);
+	});
+
+	it('should return false for IPv6 link-local addresses', () => {
+		expect(isValidHttpUrl('http://[fe80::1]')).toBe(false);
+		expect(isValidHttpUrl('http://[fe80::a00:27ff:fe4e:66a1]')).toBe(false);
+		expect(isValidHttpUrl('http://[febf:ffff::1]')).toBe(false);
+	});
 });

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -24,8 +24,11 @@ export function isValidHttpUrl(url: string): boolean {
 			/^10\./, // IPv4 private Class A: 10.0.0.0/8
 			/^172\.(1[6-9]|2[0-9]|3[0-1])\./, // IPv4 private Class B: 172.16.0.0/12
 			/^192\.168\./, // IPv4 private Class C: 192.168.0.0/16
+			/^169\.254\./, // IPv4 link-local: 169.254.0.0/16 (includes cloud metadata 169.254.169.254)
+			/^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\./, // IPv4 CGNAT: 100.64.0.0/10
 			/^::1$/, // IPv6 loopback: ::1
-			/^fd[0-9a-f]{2}:/i // IPv6 unique local addresses: fc00::/7
+			/^fd[0-9a-f]{2}:/i, // IPv6 unique local addresses: fc00::/7
+			/^fe[89ab][0-9a-f]:/i // IPv6 link-local: fe80::/10
 		];
 
 		if (privateIpRegexes.some((regex) => regex.test(hostname))) {


### PR DESCRIPTION
## Summary

`isValidHttpUrl` already rejected classic private ranges and localhost, but still allowed hosts that matter for cloud SSRF:

- IPv4 link-local `169.254.0.0/16` (including metadata `169.254.169.254`)
- IPv4 CGNAT `100.64.0.0/10`
- IPv6 link-local `fe80::/10`

Scrapers and search code fetch SERP links through this gate, so those gaps are real risk, not theoretical.

## Changes

- Extend `privateIpRegexes` in `src/lib/url.ts` with the ranges above
- Add unit coverage for the new blocks, CGNAT boundary addresses that must stay allowed, and existing private/public cases

## Verification

```bash
npx vitest run src/lib/url.test.ts
```

All 9 tests passed.