### PR TITLE
fix(stremio): drop dead locals.runtime from stream routes

### DIFF
--- a/src/pages/api/stremio/stream/movie/[name].ts
+++ b/src/pages/api/stremio/stream/movie/[name].ts
@@ -2,15 +2,10 @@ import { handleStremioStream } from '$lib/server/stremio/stream';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async ({ params, locals, request, url }) => {
-	const platform = (locals as { runtime?: { env?: Record<string, unknown> } }).runtime
-		? { env: (locals as { runtime: { env?: Record<string, unknown> } }).runtime.env }
-		: undefined;
-
 	return handleStremioStream({
 		params: params as Record<string, string | undefined>,
 		locals,
 		request,
-		url,
-		platform
+		url
 	});
 };

--- a/src/pages/api/stremio/stream/series/[name].ts
+++ b/src/pages/api/stremio/stream/series/[name].ts
@@ -2,15 +2,10 @@ import { handleStremioStream } from '$lib/server/stremio/stream';
 import type { APIRoute } from 'astro';
 
 export const GET: APIRoute = async ({ params, locals, request, url }) => {
-	const platform = (locals as { runtime?: { env?: Record<string, unknown> } }).runtime
-		? { env: (locals as { runtime: { env?: Record<string, unknown> } }).runtime.env }
-		: undefined;
-
 	return handleStremioStream({
 		params: params as Record<string, string | undefined>,
 		locals,
 		request,
-		url,
-		platform
+		url
 	});
 };


### PR DESCRIPTION
## Problem

Astro 6 no longer exposes `locals.runtime`. Middleware already loads Cloudflare env through `cloudflare:workers` and initializes services. Both Stremio stream routes still probed `(locals as { runtime? }).runtime` to build a `platform` object that `handleStremioStream` never uses (it only needs `params` + `locals`). Dead path that fights the Astro 6 migration.

## Change

In `movie/[name].ts` and `series/[name].ts`, pass `{ params, locals, request, url }` straight through and drop the runtime probe / unused `platform` argument. CORS and stream behavior unchanged; `handleStremioStream` untouched.

## How verified

- Confirmed `handleStremioStream` only destructures `params` and `locals`
- `npm run check` still reports pre-existing project-wide type issues; no new errors introduced on these two files
- Diff is limited to the two assigned routes (−12 / +2)

Finding: `stremio-drop-locals-runtime`