### PR TITLE
refactor(ui): migrate Svelte components to Svelte 5 runes

### DIFF
--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Search } from 'lucide-svelte';
 
-	export let initialQuery = '';
+	let { initialQuery = '' }: { initialQuery?: string } = $props();
 
-	let query = initialQuery;
+	let query = $state(initialQuery);
 
 	function handleSearch(event: Event) {
 		event.preventDefault();
@@ -13,7 +13,7 @@
 	}
 </script>
 
-<form on:submit={handleSearch} class="w-full">
+<form onsubmit={handleSearch} class="w-full">
 	<div
 		class="join w-full rounded-full overflow-hidden border border-base-content/10 focus-within:border-base-content/50 transition-all"
 	>

--- a/src/components/SearchBox.svelte
+++ b/src/components/SearchBox.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Search } from 'lucide-svelte';
 
-	export let suggestion = '';
+	let { suggestion = '' }: { suggestion?: string } = $props();
 
-	let query = '';
+	let query = $state('');
 
 	function handleSearch(event: Event) {
 		event.preventDefault();
@@ -13,7 +13,7 @@
 	}
 </script>
 
-<form on:submit={handleSearch} class="w-full max-w-2xl">
+<form onsubmit={handleSearch} class="w-full max-w-2xl">
 	<div
 		class="join w-full rounded-full overflow-hidden border border-base-content/10 focus-within:border-base-content/50 transition-all"
 	>

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { Sun, Moon } from 'lucide-svelte';
 
-	let isDark = false;
+	let isDark = $state(false);
 
 	onMount(() => {
 		// Check saved theme preference or default to light
@@ -19,7 +19,7 @@
 	}
 </script>
 
-<button on:click={toggleTheme} aria-label="Toggle theme" class="btn btn-ghost btn-circle">
+<button onclick={toggleTheme} aria-label="Toggle theme" class="btn btn-ghost btn-circle">
 	{#if isDark}
 		<Sun size={24} />
 	{:else}

--- a/src/components/TorrentCard.svelte
+++ b/src/components/TorrentCard.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { Download } from 'lucide-svelte';
-	export let torrent: string;
 
-	const torrentURL = new URL(torrent);
+	let { torrent }: { torrent: string } = $props();
+
+	const torrentURL = $derived(new URL(torrent));
 </script>
 
 <div class="card bg-base-100 shadow-sm border border-base-content/10 mb-3">


### PR DESCRIPTION
## Summary

The project already depends on Svelte `^5.53.6`, but four UI components still used Svelte 4 patterns (`export let`, `on:submit` / `on:click`, non-rune `let` for reactive UI state).

Migrated only:

- `src/components/SearchBar.svelte`
- `src/components/SearchBox.svelte`
- `src/components/ThemeToggle.svelte`
- `src/components/TorrentCard.svelte`

Changes:

- `export let` → `$props()` (same prop names/defaults so callers stay unchanged)
- mutable local UI state (`query`, `isDark`) → `$state`
- `torrentURL` from prop → `$derived(new URL(torrent))`
- `on:submit` / `on:click` → `onsubmit` / `onclick`
- markup, classes, and a11y attributes left as they were

## Verification

- Diff limited to the four components above
- `astro check` reports no diagnostics on these components (repo already has unrelated check noise elsewhere)

## Notes

No SearchBar/SearchBox merge, no page/layout edits, no daisyUI restyle.